### PR TITLE
Frame history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oidcsessioncheck",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidcsessioncheck",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "JavaScript library to assist with binding sessions between an OIDC OP and RP",
   "main": "sessionCheck.js",
   "scripts": {

--- a/sessionCheck.js
+++ b/sessionCheck.js
@@ -37,7 +37,6 @@
          * background OP-session checking
          */
         var iframe = document.createElement("iframe");
-        iframe.setAttribute("src", this.redirectUri);
         iframe.setAttribute("id", "sessionCheckFrame" + this.clientId);
         iframe.setAttribute("style", "display:none");
         document.getElementsByTagName("body")[0].appendChild(iframe);
@@ -69,7 +68,7 @@
         sessionStorage.setItem("sessionCheckNonce", nonce);
         document
             .getElementById("sessionCheckFrame" + config.clientId)
-            .setAttribute("src", config.opUrl + "?client_id=" + config.clientId +
+            .contentWindow.location.replace(config.opUrl + "?client_id=" + config.clientId +
                 "&response_type=id_token&scope=openid&prompt=none&redirect_uri=" +
                 config.redirectUri + "&nonce=" + nonce);
     };

--- a/sessionCheckGlobal.js
+++ b/sessionCheckGlobal.js
@@ -38,7 +38,6 @@
          * background OP-session checking
          */
         var iframe = document.createElement("iframe");
-        iframe.setAttribute("src", this.redirectUri);
         iframe.setAttribute("id", "sessionCheckFrame" + this.clientId);
         iframe.setAttribute("style", "display:none");
         document.getElementsByTagName("body")[0].appendChild(iframe);
@@ -70,7 +69,7 @@
         sessionStorage.setItem("sessionCheckNonce", nonce);
         document
             .getElementById("sessionCheckFrame" + config.clientId)
-            .setAttribute("src", config.opUrl + "?client_id=" + config.clientId +
+            .contentWindow.location.replace(config.opUrl + "?client_id=" + config.clientId +
                 "&response_type=id_token&scope=openid&prompt=none&redirect_uri=" +
                 config.redirectUri + "&nonce=" + nonce);
     };


### PR DESCRIPTION
Changes two things - does not attempt to pre-load the html in the iframe, and uses location.replace to avoid adding things to the parent frame history. From my testing this appears to fix the issue identified in #9.