### PR TITLE
feat: can override scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ The "SessionCheck" module can be loaded in several ways:
         // optional
         cooldownPeriod: 5,
         // optional
-        redirectUri: "sessionCheck.html"
+        redirectUri: "sessionCheck.html",
+        // optional
+        scope: "openid"
     });
 
 *Examples for when to check the session:*
@@ -74,6 +76,7 @@ The "SessionCheck" module can be loaded in several ways:
  - sessionClaimsHandler [optional] - function to be called after every successful session check, with latest claims included
  - redirectUri [default: sessionCheck.html] - The redirect uri registered in the OP for session-checking purposes
  - cooldownPeriod [default: 5] - Minimum time (in seconds) between requests to the opUrl
+ - scope [default: openid] - OIDC scope names (space separated) to be requested
 
 This library requires that your user is already authenticated prior to creating an instance of it. You *must* provide the current username of that user - this will be checked against the "subject" claim within the id_token that is returned by the OP. If they don't match, it is assumed that the OP and RP sessions are out of sync, and that will trigger the `invalidSessionHandler`.
 

--- a/sessionCheck.js
+++ b/sessionCheck.js
@@ -12,6 +12,7 @@
      * @param {function} config.invalidSessionHandler - function to be called once any problem with the session is detected
      * @param {string} config.redirectUri [sessionCheck.html] - The redirect uri registered in the OP for session-checking purposes
      * @param {number} config.cooldownPeriod [5] - Minimum time (in seconds) between requests to the opUrl
+     * @param {string} config.scope [openid] - Session check scope; can be space-separated list
      */
     module.exports = function (config) {
         var calculatedUriLink;
@@ -31,6 +32,7 @@
         this.opUrl = config.opUrl;
 
         this.cooldownPeriod = config.cooldownPeriod || 5;
+        this.scope = config.scope || "openid";
 
         /*
          * Attach a hidden iframe onto the main document body that is used to perform
@@ -73,7 +75,7 @@
         sessionStorage.setItem("sessionCheckNonce", nonce);
         config.iframe
             .contentWindow.location.replace(config.opUrl + "?client_id=" + config.clientId +
-                "&response_type=id_token&scope=openid&prompt=none&redirect_uri=" +
+                "&response_type=id_token&scope=" + config.scope + "&prompt=none&redirect_uri=" +
                 config.redirectUri + "&nonce=" + nonce);
     };
 

--- a/sessionCheckGlobal.js
+++ b/sessionCheckGlobal.js
@@ -13,6 +13,7 @@
      * @param {function} config.invalidSessionHandler - function to be called once any problem with the session is detected
      * @param {string} config.redirectUri [sessionCheck.html] - The redirect uri registered in the OP for session-checking purposes
      * @param {number} config.cooldownPeriod [5] - Minimum time (in seconds) between requests to the opUrl
+     * @param {string} config.scope [openid] - Session check scope; can be space-separated list
      */
     module.exports = function (config) {
         var calculatedUriLink;
@@ -32,6 +33,7 @@
         this.opUrl = config.opUrl;
 
         this.cooldownPeriod = config.cooldownPeriod || 5;
+        this.scope = config.scope || "openid";
 
         /*
          * Attach a hidden iframe onto the main document body that is used to perform
@@ -74,7 +76,7 @@
         sessionStorage.setItem("sessionCheckNonce", nonce);
         config.iframe
             .contentWindow.location.replace(config.opUrl + "?client_id=" + config.clientId +
-                "&response_type=id_token&scope=openid&prompt=none&redirect_uri=" +
+                "&response_type=id_token&scope=" + config.scope + "&prompt=none&redirect_uri=" +
                 config.redirectUri + "&nonce=" + nonce);
     };
 


### PR DESCRIPTION
Here at Calabrio we've had to make a few modifications to this library to get our ForgeRock implementation working. This pull request contains one of the changes we've made. We're currently using these changes successfully. These particular changes allow us to specify additional scope beyond the default: `...&scope=openid email calabrio&...` vs the default `...&scope=openid&...`.