### PR TITLE
feat: add ability to destroy SessionCheck instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ You will need to make sure the redirect_uri used for this is registered with the
 
 It is up to you to decide how frequently and in which circumstances you want to check the OP for session status changes. The "cooldownPeriod" setting determines the maximum frequency you want to check the OP. Regardless of how many times you call `triggerSessionCheck()` within that period, it will only be checked once. As a result, you can call this using any combination of events without worrying about flooding the OP with requests.
 
+*Cleaning up the environment*
+
+Once the SessionCheck instance is no longer needed you should `destroy()` and nullify the instance to garbase collect the instance, the related iframe, and global event handlers.
+
+    var sessionCheck = new SessionCheck(config);
+    // use sessionCheck... then when you're done with it...
+    sessionCheck.destroy();
+    sessionCheck = null;
+
 ## License
 
 MIT. Copyright ForgeRock, Inc. 2020

--- a/sessionCheckGlobal.js
+++ b/sessionCheckGlobal.js
@@ -37,12 +37,11 @@
          * Attach a hidden iframe onto the main document body that is used to perform
          * background OP-session checking
          */
-        var iframe = document.createElement("iframe");
-        iframe.setAttribute("id", "sessionCheckFrame" + this.clientId);
-        iframe.setAttribute("style", "display:none");
-        document.getElementsByTagName("body")[0].appendChild(iframe);
-
-        window.addEventListener("message", function (e) {
+        this.iframe = document.createElement("iframe");
+        this.iframe.setAttribute("id", "sessionCheckFrame" + this.clientId);
+        this.iframe.setAttribute("style", "display:none");
+        document.getElementsByTagName("body")[0].appendChild(this.iframe);
+        this.eventListenerHandle = function (e) {
             if (e.origin !== document.location.origin) {
                 return;
             }
@@ -52,7 +51,8 @@
             if (e.data.message === "sessionCheckSucceeded" && config.sessionClaimsHandler) {
                 config.sessionClaimsHandler(e.data.claims);
             }
-        });
+        };
+        window.addEventListener("message", this.eventListenerHandle);
 
         sessionStorage.setItem("sessionCheckSubject", this.subject);
         return this;
@@ -65,10 +65,14 @@
      * the sessionCheckFrame code.
      */
     var idTokenRequest = function(config) {
+        if (!config.iframe) {
+            // eslint-disable-next-line no-console
+            console.warn("This session check instance has been destroyed");
+            return;
+        }
         var nonce = Math.floor(Math.random() * 100000);
         sessionStorage.setItem("sessionCheckNonce", nonce);
-        document
-            .getElementById("sessionCheckFrame" + config.clientId)
+        config.iframe
             .contentWindow.location.replace(config.opUrl + "?client_id=" + config.clientId +
                 "&response_type=id_token&scope=openid&prompt=none&redirect_uri=" +
                 config.redirectUri + "&nonce=" + nonce);
@@ -92,6 +96,36 @@
         idTokenRequestCooldown.call(this);
     };
 
+    /**
+     * Destroys the OIDC session check instance to allow garbage collection; removes the iframe and associated iframe event listeners.
+     * Recommend dereferencing of session check after destruction to prevent use of impotent SessionCheck instance.
+     * @example
+     * // Good example
+     * this.sc = new SessionCheck(config)
+     * // use this.sc, then...
+     * this.sc.destroy()
+     * this.sc = null
+     * @example
+     * // Good example
+     * function() {
+     *   const sc = new SessionCheck(config)
+     *   // use sc, then...
+     *   sc.destroy()
+     * } // at the end of the function the session check goes out of scope and is cleaned up by the garbage collector, along with the iframe and event handler.
+     * @example
+     * // Bad example
+     * this.sc = new SessionCheck(config)
+     * // use this.sc, then...
+     * this.sc = null // does not remove iframe or event listener, meaning events will still occur and the garbage collector will not collect this.sc
+     */
+    module.exports.prototype.destroy = function() {
+        if (this.iframe && this.iframe.parentNode) {
+            this.iframe.parentNode.removeChild(this.iframe);
+        }
+        this.iframe = null;
+        removeEventListener("message", this.eventListenerHandle, false);
+        this.eventListenerHandle = null;
+    };
 }());
 
 },{}]},{},[1])(1)


### PR DESCRIPTION
Here at Calabrio we've had to make a few modifications to this library to get our ForgeRock implementation working. This pull request contains one of the changes we've made. We're currently using these changes successfully. These particular changes allow us to destroy the session check instance when not in use, specifically when we've confirmed we don't have a valid session and must navigate the app without a session (e.g. login page, initial system configuration, etc.). We considered just removing the iframe, but that would have broken the abstraction and would have left orphaned event handlers that would incorrectly handle iframe events from other session check instances.