### PR TITLE
Include reason to session check failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The "SessionCheck" module can be loaded in several ways:
         clientId: "myRP",
         opUrl: "https://login.example.com/oauth2/authorize",
         subject: loggedInUsername,
-        invalidSessionHandler: function () {
+        invalidSessionHandler: function (reason) {
             logoutFromRP();
         },
         sessionClaimsHandler: function (claims) {
@@ -72,7 +72,7 @@ The "SessionCheck" module can be loaded in several ways:
  - subject - The user currently logged into the RP
  - clientId - The id of this RP client within the OP
  - opUrl - Full URL to the OP Authorization Endpoint
- - invalidSessionHandler - function to be called once any problem with the session is detected
+ - invalidSessionHandler - function to be called once any problem with the session is detected, with reason to invalid session included
  - sessionClaimsHandler [optional] - function to be called after every successful session check, with latest claims included
  - redirectUri [default: sessionCheck.html] - The redirect uri registered in the OP for session-checking purposes
  - cooldownPeriod [default: 5] - Minimum time (in seconds) between requests to the opUrl

--- a/sessionCheck.js
+++ b/sessionCheck.js
@@ -47,7 +47,7 @@
                 return;
             }
             if (e.data.message === "sessionCheckFailed" && config.invalidSessionHandler) {
-                config.invalidSessionHandler();
+                config.invalidSessionHandler(e.data.reason);
             }
             if (e.data.message === "sessionCheckSucceeded" && config.sessionClaimsHandler) {
                 config.sessionClaimsHandler(e.data.claims);

--- a/sessionCheckFrame.js
+++ b/sessionCheckFrame.js
@@ -56,14 +56,16 @@
         var new_claims = getIdTokenClaims(implict_params.id_token);
         if (sessionStorage.getItem("sessionCheckNonce") !== new_claims.nonce) {
             parent.postMessage({
-                "message": "sessionCheckFailed"
+                "message": "sessionCheckFailed",
+                "reason": "nonce_mismatch"
             }, document.location.origin);
             return;
         }
 
         if (new_claims.sub !== sessionStorage.getItem("sessionCheckSubject")) {
             parent.postMessage({
-                "message": "sessionCheckFailed"
+                "message": "sessionCheckFailed",
+                "reason": "subject_mismatch"
             }, document.location.origin);
             return;
         }
@@ -74,7 +76,8 @@
         }, document.location.origin);
     } else if (implict_params.error) {
         parent.postMessage({
-            "message": "sessionCheckFailed"
+            "message": "sessionCheckFailed",
+            "reason": implict_params.error
         }, document.location.origin);
         return;
     }

--- a/sessionCheckGlobal.js
+++ b/sessionCheckGlobal.js
@@ -48,7 +48,7 @@
                 return;
             }
             if (e.data.message === "sessionCheckFailed" && config.invalidSessionHandler) {
-                config.invalidSessionHandler();
+                config.invalidSessionHandler(e.data.reason);
             }
             if (e.data.message === "sessionCheckSucceeded" && config.sessionClaimsHandler) {
                 config.sessionClaimsHandler(e.data.claims);


### PR DESCRIPTION
Make it possible to distinguish between nonce, subject or other failures in callback.